### PR TITLE
Allow multi space alignment (via no-multi-spaces)

### DIFF
--- a/rules/white-space.js
+++ b/rules/white-space.js
@@ -43,6 +43,8 @@ module.exports = {
     'key-spacing': ['error', { mode: 'minimum' }],
     'no-multi-spaces': ['error', { exceptions: {
       Property: true,
+      ArrayExpression: true,
+      CallExpression: true,
     } }],
     'comma-spacing': 'error',
 


### PR DESCRIPTION
```javascript
// align end (requires additional rule change)
[  'foo',    'bar']
['apple', 'banana']

// align start (works as-is)
['foo',   'bar']
['apple', 'banana']
```