### PR TITLE
Enabled es6 flag for env option to allow for ES6 globals such as Set,Map etc.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,9 @@ module.exports = {
     './rules/syntax',
     './rules/white-space',
   ].map(require.resolve),
+  env: {
+    es6: true,
+  },
   parserOptions: {
     ecmaVersion: 2017,
     sourceType: 'module',


### PR DESCRIPTION
See https://github.com/eslint/eslint/issues/7984.

The parserOptions config only handles options for the parser (e.g. if you're using ES6 syntax). However, it doesn't affect the list of availale globals, which is used by rules like no-undef. To set ES6 globals, you should add env: {es6: true} to your config (as you mentioned you did).