### PR TITLE
Rename project and mark it private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
-  "name": "@prosperworks/eslint-config",
+  "name": "eslint-config-copper",
   "version": "3.0.0",
   "description": "A mostly reasonable approach to JavaScript.",
   "repository": "github:ProsperWorks/js-style",
+  "private": true,
   "author": "ProsperWorks",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Moving away from managing this via npm repo so we don't have to administrate an npm org.

Also is a nice opportunity to rebrand ProsperWorks->Copper

Marked it "private" so we don't accidentally publish to npm repo anymore